### PR TITLE
u-boot: upgrade to 2018.07 to fix the build issue

### DIFF
--- a/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi/Add_Spi_Nor_Flash_Boot_Support.patch
+++ b/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi/Add_Spi_Nor_Flash_Boot_Support.patch
@@ -1,11 +1,12 @@
 diff --git a/configs/orangepi_zero_defconfig b/configs/orangepi_zero_defconfig
-index ac44937b16..7084b6c3e2 100644
+index 6afd4a3bfa..66904822ed 100644
 --- a/configs/orangepi_zero_defconfig
 +++ b/configs/orangepi_zero_defconfig
-@@ -15,3 +15,6 @@ CONFIG_SPL=y
- CONFIG_SPL_SPI_SUNXI=y
+@@ -14,3 +14,6 @@ CONFIG_CONSOLE_MUX=y
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
+ CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +CONFIG_SPL_SPI_FLASH_SUPPORT=y
 +CONFIG_SPI_BOOT=y
 +CONFIG_SPL_SPI_SUNXI=y
+

--- a/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi_2018.07.bb
+++ b/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi_2018.07.bb
@@ -1,0 +1,42 @@
+DESCRIPTION="Upstream's U-boot configured for sunxi devices"
+
+require recipes-bsp/u-boot/u-boot.inc
+
+DEPENDS += "dtc-native"
+
+LICENSE = "GPLv2"
+
+LIC_FILES_CHKSUM = "\
+file://Licenses/Exceptions;md5=338a7cb1e52d0d1951f83e15319a3fe7 \
+file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5 \
+file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c \
+file://Licenses/eCos-2.0.txt;md5=b338cb12196b5175acd3aa63b0a0805c \
+file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+file://Licenses/ibm-pibs.txt;md5=c49502a55e35e0a8a1dc271d944d6dba \
+file://Licenses/isc.txt;md5=ec65f921308235311f34b79d844587eb \
+file://Licenses/lgpl-2.0.txt;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
+file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
+file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2 \
+"
+
+SRC_URI = " \
+  git://git.denx.de/u-boot.git;branch=master \
+  file://boot.cmd \
+  file://Add_Spi_Nor_Flash_Boot_Support.patch \
+  file://0001-sunxi-h3-Fix-PLL1-setup-to-never-use-dividers.patch \
+"
+
+SRCREV = "8c5d4fd0ec222701598a27b26ab7265d4cee45a3"
+
+PV = "v2018.07+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+SPL_BINARY="u-boot-sunxi-with-spl.bin"
+
+UBOOT_ENV_SUFFIX = "scr"
+UBOOT_ENV = "boot"
+
+do_compile_append() {
+    ${B}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}
+}


### PR DESCRIPTION
The current version of u-boot (2017.03) has an error while building lib_fdt, it can't find the required compiler.
Here I upgrade the uboot to latest release version, keep the patches for Orange Pi Zero.

Tested (compile & run) on Orange Pi Zero, the commit works fine.