### PR TITLE
Update u-boot-opi_2018.07.bb

### DIFF
--- a/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi_2018.07.bb
+++ b/meta-opi/recipes-bsp/u-boot-opi/u-boot-opi_2018.07.bb
@@ -2,7 +2,7 @@ DESCRIPTION="Upstream's U-boot configured for sunxi devices"
 
 require recipes-bsp/u-boot/u-boot.inc
 
-DEPENDS += "dtc-native"
+DEPENDS += "dtc-native bison-native"
 
 LICENSE = "GPLv2"
 


### PR DESCRIPTION
When I was using meta-opi with latest yocto and openembedded layers, I got an error: 
bison: not found
This patch fixes it